### PR TITLE
Revert "Feature/portable suites"

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	LocalAddress       string          `long:"source-ip" description:"Local source IP address to use for making connections"`
 	Senders            int             `short:"s" long:"senders" default:"1000" description:"Number of send goroutines to use"`
 	Debug              bool            `long:"debug" description:"Include debug fields in the output."`
-	Flush              bool            `long:"flush" description:"Flush after each line of output."`
 	GOMAXPROCS         int             `long:"gomaxprocs" default:"0" description:"Set GOMAXPROCS"`
 	ConnectionsPerHost int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	ReadLimitPerHost   int             `long:"read-limit-per-host" default:"96" description:"Maximum total kilobytes to read for a single host (default 96kb)"`

--- a/output.go
+++ b/output.go
@@ -153,9 +153,6 @@ func OutputResults(w *bufio.Writer, results <-chan []byte) error {
 		if err := w.WriteByte('\n'); err != nil {
 			return err
 		}
-		if config.Flush {
-			w.Flush()
-		}
 	}
 	return nil
 }

--- a/tls.go
+++ b/tls.go
@@ -91,7 +91,6 @@ func (t *TLSFlags) GetTLSConfigForTarget(target *ScanTarget) (*tls.Config, error
 
 	// TODO: Find standard names
 	cipherMap := map[string][]uint16{
-		"portable":        tls.PortableCiphers,
 		"dhe-only":        tls.DHECiphers,
 		"ecdhe-only":      tls.ECDHECiphers,
 		"exports-dh-only": tls.DHEExportCiphers,


### PR DESCRIPTION
Reverts PalindromeLabs/zgrab2#2 because I'm seeing the following error when I try to build:
```
../../tls.go:94:22: undefined: "github.com/zmap/zcrypto/tls".PortableCiphers
make: *** [Makefile:24: zgrab2] Error 2
```